### PR TITLE
troubleshoot f8a-stacks-report failures by saving failed history

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -15,7 +15,7 @@ objects:
       description: f8a-stacks-report
   spec:
     successfulJobsHistoryLimit: 4
-    failedJobsHistoryLimit: 0
+    failedJobsHistoryLimit: 1
     concurrencyPolicy: "Forbid"
     schedule: "${CRON_SCHEDULE}"
     jobTemplate:


### PR DESCRIPTION
f8a-stacks-report pod did not get created in staging, hence this PR. 