### PR TITLE
Increasing memory_request and cron job frequency

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -191,7 +191,7 @@ parameters:
   displayName: Schedule
   required: true
   name: CRON_SCHEDULE
-  value: "0 0 * * *"
+  value: "0 */3 * * *"
 
 - description: CPU request
   displayName: CPU request
@@ -209,7 +209,7 @@ parameters:
   displayName: Memory request
   required: true
   name: MEMORY_REQUEST
-  value: "256Mi"
+  value: "1024Mi"
 
 - description: Memory limit
   displayName: Memory limit


### PR DESCRIPTION
memory_request increased as pod is throwing OOM at staging. Cron job frequency increased to every 3 hours to test changes faster, will roll back once things stabilize.