### PR TITLE
Update default value for SENTRY_API_ISSUES and SENTRY_API_TAGS

### DIFF
--- a/f8a_report/sentry_report_helper.py
+++ b/f8a_report/sentry_report_helper.py
@@ -15,14 +15,13 @@ class SentryReportHelper:
     def __init__(self):
         """Init method for SentryReportHelper."""
         self.s3 = S3Helper()
-        self.sentry_api_issues = os.getenv('SENTRY_API_ISSUES', 'https://errortracking'
-                                                                '.prod-preview.openshift'
-                                                                '.io/api/0/projects/openshift_io/'
+        self.sentry_api_issues = os.getenv('SENTRY_API_ISSUES', 'https://sentry.devshift.net/'
+                                                                'api/0/projects/sentry/'
                                                                 'fabric8-analytics-production/'
                                                                 'issues/')
         self.sentry_api_tags = os.getenv('SENTRY_API_TAGS',
-                                         'https://errortracking.prod-preview'
-                                         '.openshift.io/api/0/issues/')
+                                         'https://sentry.devshift.net/'
+                                         'api/0/issues/')
         self.sentry_token = os.getenv('SENTRY_AUTH_TOKEN', '')
 
     def retrieve_sentry_logs(self, start_date, end_date):

--- a/tests/test_sentry_report_helper.py
+++ b/tests/test_sentry_report_helper.py
@@ -95,10 +95,10 @@ sentry_tags_res_nostack = {
 @responses.activate
 def test_retrieve_sentry_logs_success():
     """Test retrieve sentry logs."""
-    responses.add(responses.GET, 'https://errortracking.prod-preview.openshift.io/api/0/projects/'
-                                 'openshift_io/fabric8-analytics-production/issues/'
+    responses.add(responses.GET, 'https://sentry.devshift.net/api/0/projects/'
+                                 'sentry/fabric8-analytics-production/issues/'
                                  '?statsPeriod=24h', json=sentry_issues_res, status=200)
-    responses.add(responses.GET, 'https://errortracking.prod-preview.openshift.io/api/0/issues/'
+    responses.add(responses.GET, 'https://sentry.devshift.net/api/0/issues/'
                                  '12666/events/latest/', json=sentry_tags_res, status=200)
     res = sobj.retrieve_sentry_logs('2019-05-14', '2019-05-15')
     expected_output = {"error_report": {"bayesian-data-importer":
@@ -123,11 +123,11 @@ def test_retrieve_sentry_logs_failure():
 @responses.activate
 def test_retrieve_sentry_logs_nostacktrace():
     """Test retrieve sentry logs."""
-    responses.add(responses.GET, 'https://errortracking.prod-preview.openshift.io/api/0/projects/'
-                                 'openshift_io/fabric8-analytics-production/issues/'
+    responses.add(responses.GET, 'https://sentry.devshift.net/api/0/projects/'
+                                 'sentry/fabric8-analytics-production/issues/'
                                  '?statsPeriod=24h',
                   json=sentry_issues_res, status=200)
-    responses.add(responses.GET, 'https://errortracking.prod-preview.openshift.io/api/0/issues/'
+    responses.add(responses.GET, 'https://sentry.devshift.net/api/0/issues/'
                                  '12666/events/latest/', json=sentry_tags_res_nostack, status=200)
     res = sobj.retrieve_sentry_logs('2019-05-14', '2019-05-15')
     expected_output = {"error_report": {"bayesian-data-importer":


### PR DESCRIPTION
Updating Default Values for env var : SENTRY_API_ISSUES and SENTRY_API_TAGS
Pointing to the new app-sre managed sentry instance : 
https://sentry.devshift.net/sentry/fabric8-analytics-production/