### PR TITLE
Using env_var 'SENTRY_URL' for 'sentry_api_issues' and 'sentry_api_tags'

### DIFF
--- a/f8a_report/sentry_report_helper.py
+++ b/f8a_report/sentry_report_helper.py
@@ -15,13 +15,12 @@ class SentryReportHelper:
     def __init__(self):
         """Init method for SentryReportHelper."""
         self.s3 = S3Helper()
-        self.sentry_api_issues = os.getenv('SENTRY_API_ISSUES', 'https://sentry.devshift.net/'
-                                                                'api/0/projects/sentry/'
-                                                                'fabric8-analytics-production/'
-                                                                'issues/')
-        self.sentry_api_tags = os.getenv('SENTRY_API_TAGS',
-                                         'https://sentry.devshift.net/'
-                                         'api/0/issues/')
+        self.sentry_api_issues = os.getenv('SENTRY_URL', '')
+        self.sentry_api_tags = self.sentry_api_issues + "/api/0/issues/"
+        if self.sentry_api_issues == "https://sentry.stage.devshift.net":
+            self.sentry_api_issues += "/api/0/projects/sentry/fabric8-analytics-stage/issues/"
+        else:
+            self.sentry_api_issues += "/api/0/projects/sentry/fabric8-analytics-production/issues/"
         self.sentry_token = os.getenv('SENTRY_AUTH_TOKEN', '')
 
     def retrieve_sentry_logs(self, start_date, end_date):

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -132,6 +132,11 @@ objects:
                     secretKeyRef:
                       name: worker
                       key: sentry-auth-token
+                - name: SENTRY_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: worker
+                      key: sentry-url
                 - name: REPORT_BUCKET_NAME
                   valueFrom:
                     secretKeyRef:

--- a/tests/test_sentry_report_helper.py
+++ b/tests/test_sentry_report_helper.py
@@ -4,6 +4,9 @@ from f8a_report.sentry_report_helper import SentryReportHelper
 import responses
 
 sobj = SentryReportHelper()
+sobj.sentry_api_issues = 'https://sentry.devshift.net'
+sobj.sentry_api_issues += '/api/0/projects/sentry/fabric8-analytics-production/issues/'
+sobj.sentry_api_tags = 'https://sentry.devshift.net/api/0/issues/'
 
 sentry_issues_res = [{
     "lastSeen": "2019-05-15T06:50:10Z",


### PR DESCRIPTION
Using env_var 'SENTRY_URL'  for  'sentry_api_issues' and 'sentry_api_tags' with respect to stage and production sentry.