### PR TITLE
Using env-var 'SENTRY_URL' with 'SENTRY_API_TAGS' and 'SENTRY_API_ISSUES'

### DIFF
--- a/f8a_report/sentry_report_helper.py
+++ b/f8a_report/sentry_report_helper.py
@@ -15,12 +15,10 @@ class SentryReportHelper:
     def __init__(self):
         """Init method for SentryReportHelper."""
         self.s3 = S3Helper()
-        self.sentry_api_issues = os.getenv('SENTRY_URL', '')
-        self.sentry_api_tags = self.sentry_api_issues + "/api/0/issues/"
-        if self.sentry_api_issues == "https://sentry.stage.devshift.net":
-            self.sentry_api_issues += "/api/0/projects/sentry/fabric8-analytics-stage/issues/"
-        else:
-            self.sentry_api_issues += "/api/0/projects/sentry/fabric8-analytics-production/issues/"
+        self.sentry_url = os.getenv('SENTRY_URL', 'https://sentry.devshift.net')
+        self.sentry_api_issues = self.sentry_url + os.getenv(
+            'SENTRY_API_ISSUES', '/api/0/projects/sentry/fabric8-analytics-production/issues/')
+        self.sentry_api_tags = self.sentry_url + os.getenv('SENTRY_API_TAGS', '/api/0/issues/')
         self.sentry_token = os.getenv('SENTRY_AUTH_TOKEN', '')
 
     def retrieve_sentry_logs(self, start_date, end_date):

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -285,3 +285,15 @@ parameters:
   name: GENERATE_MANIFESTS
   value: "False"
 
+- description: "Generate sentry-api-issues URL"
+  displayName: SENTRY API ISSUES
+  required: true
+  name: SENTRY_API_ISSUES
+  value: "/api/0/projects/sentry/fabric8-analytics-production/issues/"
+
+- description: "Generate sentry-api-tags URL"
+  displayName: SENTRY API TAGS
+  required: true
+  name: SENTRY_API_TAGS
+  value: "/api/0/issues/"
+

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -40,6 +40,10 @@ objects:
                   value: ${KEEP_WORKER_RESULT_NUM_DAYS}
                 - name: GENERATE_MANIFESTS
                   value: ${GENERATE_MANIFESTS}
+                - name: SENTRY_API_ISSUES
+                  value: ${SENTRY_API_ISSUES}
+                - name: SENTRY_API_TAGS
+                  value: ${SENTRY_API_TAGS}
                 - name: AWS_S3_SECRET_ACCESS_KEY
                   valueFrom:
                     secretKeyRef:

--- a/tests/test_sentry_report_helper.py
+++ b/tests/test_sentry_report_helper.py
@@ -4,9 +4,6 @@ from f8a_report.sentry_report_helper import SentryReportHelper
 import responses
 
 sobj = SentryReportHelper()
-sobj.sentry_api_issues = 'https://sentry.devshift.net'
-sobj.sentry_api_issues += '/api/0/projects/sentry/fabric8-analytics-production/issues/'
-sobj.sentry_api_tags = 'https://sentry.devshift.net/api/0/issues/'
 
 sentry_issues_res = [{
     "lastSeen": "2019-05-15T06:50:10Z",


### PR DESCRIPTION
Using env-var 'SENTRY_URL' with 'SENTRY_API_TAGS' and 'SENTRY_API_ISSUES' to generate 'sentry_api_tags' and 'sentry_api_issues' URLs.

Adding all 3 env-var to template file.