### PR TITLE
reverting Manifest Generation to daily

### DIFF
--- a/f8a_report/main.py
+++ b/f8a_report/main.py
@@ -42,11 +42,12 @@ def main():
         except Exception as e:
             logger.error("Exception in Retraining {}".format(e))
             pass
-        logger.info(os.environ.get('GENERATE_MANIFESTS', 'False'))
-        if os.environ.get('GENERATE_MANIFESTS', 'False') in ('True', 'true', '1'):
-            logger.info('Generating Manifests based on last 1 week Stack Analyses calls.')
-            stacks = r.retrieve_stack_analyses_content(start_date_wk, end_date_wk)
-            manifest_interface(stacks)
+
+    logger.info(os.environ.get('GENERATE_MANIFESTS', 'False'))
+    if os.environ.get('GENERATE_MANIFESTS', 'False') in ('True', 'true', '1'):
+        logger.info('Generating Manifests based on last 1 week Stack Analyses calls.')
+        stacks = r.retrieve_stack_analyses_content(start_date_wk, end_date_wk)
+        manifest_interface(stacks)
 
     # Generate a monthly venus report
     if time_to_generate_monthly_report(today):


### PR DESCRIPTION
Reverts fabric8-analytics/f8a-stacks-report#147

As Build is Passing, https://ci.centos.org/job/devtools-f8a-stacks-report-build-master/94/

This PR is to check the Manifest Generation on stage. This is a Temporary revert. It will be reverted