### PR TITLE
chore: Purge stack_analyses_request, worker_results and api_requests tables

### DIFF
--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -80,7 +80,7 @@ class ReportHelper:
             logger.info('Cleanup of Celery Meta tables complete')
 
             # Number of days to retain the celery woker_result data
-            num_days_workerdata = os.environ.get('KEEP_WORKER_RESULT_NUM_DAYS', '60')
+            num_days_workerdata = os.environ.get('KEEP_WORKER_RESULT_NUM_DAYS', '365')
             # query to delete the worker_result data
             query = sql.SQL('DELETE FROM worker_results '
                             'WHERE ended_at <= NOW() - interval \'%s day\';')
@@ -103,18 +103,6 @@ class ReportHelper:
             # Log the message returned from db cursor
             logger.info('%r' % self.cursor.statusmessage)
             logger.info('Cleanup of Stack Analyses tables complete')
-
-            # Number of days to retain the worker_results data
-            num_days_worker_results = os.environ.get('KEEP_WORKER_RESULTS_NUM_DAYS', '365')
-            # query to delete the stack_analyses_request data
-            query = sql.SQL('DELETE FROM worker_results '
-                            'WHERE DATE_DONE <= NOW() - interval \'%s day\';')
-            logger.info('Starting to clean up Worker results tables')
-            # Execute the query
-            self.cursor.execute(query.as_string(self.conn) % (num_days_worker_results))
-            # Log the message returned from db cursor
-            logger.info('%r' % self.cursor.statusmessage)
-            logger.info('Cleanup of Worker results tables complete')
         except Exception as e:
             logger.error('CleanupDatabaseError: %r' % e)
 

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -91,6 +91,31 @@ class ReportHelper:
             logger.info('%r' % self.cursor.statusmessage)
             logger.info('Cleanup of Worker Result data tables complete')
 
+            # Number of days to retain the package_analyses data
+            num_days_package_analyses = os.environ.get('KEEP_PACKAGE_ANALYSES_NUM_DAYS', '30')
+            # query to delete the worker_result data
+            query = sql.SQL('DELETE FROM package_analyses '
+                            'WHERE ended_at <= NOW() - interval \'%s day\';')
+            logger.info('Starting to clean up Package Analyses data tables')
+            # Execute the query
+            self.cursor.execute(query.as_string(self.conn) % (num_days_package_analyses))
+            # Log the message returned from db cursor
+            logger.info('%r' % self.cursor.statusmessage)
+            logger.info('Cleanup of Package Analyses data tables complete')
+
+            # Number of days to retain the package_worker_result data
+            num_days_package_worker_result = os.environ.get
+            ('KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS', '30')
+            # query to delete the worker_result data
+            query = sql.SQL('DELETE FROM package_worker_results '
+                            'WHERE ended_at <= NOW() - interval \'%s day\';')
+            logger.info('Starting to clean up Package Worker Result data tables')
+            # Execute the query
+            self.cursor.execute(query.as_string(self.conn) % (num_days_package_worker_result))
+            # Log the message returned from db cursor
+            logger.info('%r' % self.cursor.statusmessage)
+            logger.info('Cleanup of Package Worker Result data tables complete')
+
             # Number of days to retain the stack_analyses_request data
             num_days_stack_analyses_request = os.environ.get
             ('KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS', '180')

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -103,6 +103,18 @@ class ReportHelper:
             # Log the message returned from db cursor
             logger.info('%r' % self.cursor.statusmessage)
             logger.info('Cleanup of Stack Analyses tables complete')
+
+            # Number of days to retain the api_requests data
+            num_days_api_requests = os.environ.get('KEEP_API_REQUESTS_NUM_DAYS', '180')
+            # query to delete the api_requests data
+            query = sql.SQL('DELETE FROM api_requests '
+                            'WHERE ended_at <= NOW() - interval \'%s day\';')
+            logger.info('Starting to clean up api requests data tables')
+            # Execute the query
+            self.cursor.execute(query.as_string(self.conn) % (num_days_api_requests))
+            # Log the message returned from db cursor
+            logger.info('%r' % self.cursor.statusmessage)
+            logger.info('Cleanup of api requests data tables complete')
         except Exception as e:
             logger.error('CleanupDatabaseError: %r' % e)
 

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -64,82 +64,101 @@ class ReportHelper:
 
         self.emr_api = os.getenv('EMR_API', 'http://f8a-emr-deployment:6006')
 
+    def cleanup_celery_task_metadata(self):
+        """Cleanup celery task metadata tables on a periodic basis."""
+        # Number of days to retain the celery task_meta data
+        num_days_metadata = os.environ.get('KEEP_DB_META_NUM_DAYS', '30')
+        # query to delete the celery task_meta data
+        query = sql.SQL('DELETE FROM celery_taskmeta '
+                        'WHERE DATE_DONE <= NOW() - interval \'%s day\';')
+        logger.info('Starting to clean up Celery Meta tables')
+        # Execute the query
+        self.cursor.execute(query.as_string(self.conn) % (num_days_metadata))
+        # Log the message returned from db cursor
+        logger.info('%r' % self.cursor.statusmessage)
+        logger.info('Cleanup of Celery Meta tables complete')
+
+    def cleanup_celery_worker_results(self):
+        """Cleanup worker results data tables on a periodic basis."""
+        # Number of days to retain the celery woker_result data
+        num_days_workerdata = os.environ.get('KEEP_WORKER_RESULT_NUM_DAYS', '30')
+        # query to delete the worker_result data
+        query = sql.SQL('DELETE FROM worker_results '
+                        'WHERE ended_at <= NOW() - interval \'%s day\';')
+        logger.info('Starting to clean up Worker Result data tables')
+        # Execute the query
+        self.cursor.execute(query.as_string(self.conn) % (num_days_workerdata))
+        # Log the message returned from db cursor
+        logger.info('%r' % self.cursor.statusmessage)
+        logger.info('Cleanup of Worker Result data tables complete')
+
+    def cleanup_package_analyses_data(self):
+        """Cleanup package analyses data tables on a periodic basis."""
+        # Number of days to retain the package_analyses data
+        num_days_package_analyses = os.environ.get('KEEP_PACKAGE_ANALYSES_NUM_DAYS', '30')
+        # query to delete the worker_result data
+        query = sql.SQL('DELETE FROM package_analyses '
+                        'WHERE ended_at <= NOW() - interval \'%s day\';')
+        logger.info('Starting to clean up Package Analyses data tables')
+        # Execute the query
+        self.cursor.execute(query.as_string(self.conn) % (num_days_package_analyses))
+        # Log the message returned from db cursor
+        logger.info('%r' % self.cursor.statusmessage)
+        logger.info('Cleanup of Package Analyses data tables complete')
+
+    def cleanup_package_worker_results_data(self):
+        """Cleanup package worker results data tables on a periodic basis."""
+        # Number of days to retain the package_worker_result data
+        num_days_package_worker_result = os.environ.get
+        ('KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS', '30')
+        # query to delete the worker_result data
+        query = sql.SQL('DELETE FROM package_worker_results '
+                        'WHERE ended_at <= NOW() - interval \'%s day\';')
+        logger.info('Starting to clean up Package Worker Result data tables')
+        # Execute the query
+        self.cursor.execute(query.as_string(self.conn) % (num_days_package_worker_result))
+        # Log the message returned from db cursor
+        logger.info('%r' % self.cursor.statusmessage)
+        logger.info('Cleanup of Package Worker Result data tables complete')
+
+    def cleanup_stack_analyses_request_data(self):
+        """Cleanup stack analyses data tables on a periodic basis."""
+        # Number of days to retain the stack_analyses_request data
+        num_days_stack_analyses_request = os.environ.get
+        ('KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS', '180')
+        # query to delete the stack_analyses_request data
+        query = sql.SQL('DELETE FROM stack_analyses_request '
+                        'WHERE DATE_DONE <= NOW() - interval \'%s day\';')
+        logger.info('Starting to clean up Stack Analyses tables')
+        # Execute the query
+        self.cursor.execute(query.as_string(self.conn) % (num_days_stack_analyses_request))
+        # Log the message returned from db cursor
+        logger.info('%r' % self.cursor.statusmessage)
+        logger.info('Cleanup of Stack Analyses tables complete')
+
+    def cleanup_api_requests_data(self):
+        """Cleanup api request data tables on a periodic basis."""
+        # Number of days to retain the api_requests data
+        num_days_api_requests = os.environ.get('KEEP_API_REQUESTS_NUM_DAYS', '180')
+        # query to delete the api_requests data
+        query = sql.SQL('DELETE FROM api_requests '
+                        'WHERE ended_at <= NOW() - interval \'%s day\';')
+        logger.info('Starting to clean up api requests data tables')
+        # Execute the query
+        self.cursor.execute(query.as_string(self.conn) % (num_days_api_requests))
+        # Log the message returned from db cursor
+        logger.info('%r' % self.cursor.statusmessage)
+        logger.info('Cleanup of api requests data tables complete')
+
     def cleanup_db_tables(self):
         """Cleanup RDS data tables on a periodic basis."""
         try:
-            # Number of days to retain the celery task_meta data
-            num_days_metadata = os.environ.get('KEEP_DB_META_NUM_DAYS', '30')
-            # query to delete the celery task_meta data
-            query = sql.SQL('DELETE FROM celery_taskmeta '
-                            'WHERE DATE_DONE <= NOW() - interval \'%s day\';')
-            logger.info('Starting to clean up Celery Meta tables')
-            # Execute the query
-            self.cursor.execute(query.as_string(self.conn) % (num_days_metadata))
-            # Log the message returned from db cursor
-            logger.info('%r' % self.cursor.statusmessage)
-            logger.info('Cleanup of Celery Meta tables complete')
-
-            # Number of days to retain the celery woker_result data
-            num_days_workerdata = os.environ.get('KEEP_WORKER_RESULT_NUM_DAYS', '30')
-            # query to delete the worker_result data
-            query = sql.SQL('DELETE FROM worker_results '
-                            'WHERE ended_at <= NOW() - interval \'%s day\';')
-            logger.info('Starting to clean up Worker Result data tables')
-            # Execute the query
-            self.cursor.execute(query.as_string(self.conn) % (num_days_workerdata))
-            # Log the message returned from db cursor
-            logger.info('%r' % self.cursor.statusmessage)
-            logger.info('Cleanup of Worker Result data tables complete')
-
-            # Number of days to retain the package_analyses data
-            num_days_package_analyses = os.environ.get('KEEP_PACKAGE_ANALYSES_NUM_DAYS', '30')
-            # query to delete the worker_result data
-            query = sql.SQL('DELETE FROM package_analyses '
-                            'WHERE ended_at <= NOW() - interval \'%s day\';')
-            logger.info('Starting to clean up Package Analyses data tables')
-            # Execute the query
-            self.cursor.execute(query.as_string(self.conn) % (num_days_package_analyses))
-            # Log the message returned from db cursor
-            logger.info('%r' % self.cursor.statusmessage)
-            logger.info('Cleanup of Package Analyses data tables complete')
-
-            # Number of days to retain the package_worker_result data
-            num_days_package_worker_result = os.environ.get
-            ('KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS', '30')
-            # query to delete the worker_result data
-            query = sql.SQL('DELETE FROM package_worker_results '
-                            'WHERE ended_at <= NOW() - interval \'%s day\';')
-            logger.info('Starting to clean up Package Worker Result data tables')
-            # Execute the query
-            self.cursor.execute(query.as_string(self.conn) % (num_days_package_worker_result))
-            # Log the message returned from db cursor
-            logger.info('%r' % self.cursor.statusmessage)
-            logger.info('Cleanup of Package Worker Result data tables complete')
-
-            # Number of days to retain the stack_analyses_request data
-            num_days_stack_analyses_request = os.environ.get
-            ('KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS', '180')
-            # query to delete the stack_analyses_request data
-            query = sql.SQL('DELETE FROM stack_analyses_request '
-                            'WHERE DATE_DONE <= NOW() - interval \'%s day\';')
-            logger.info('Starting to clean up Stack Analyses tables')
-            # Execute the query
-            self.cursor.execute(query.as_string(self.conn) % (num_days_stack_analyses_request))
-            # Log the message returned from db cursor
-            logger.info('%r' % self.cursor.statusmessage)
-            logger.info('Cleanup of Stack Analyses tables complete')
-
-            # Number of days to retain the api_requests data
-            num_days_api_requests = os.environ.get('KEEP_API_REQUESTS_NUM_DAYS', '180')
-            # query to delete the api_requests data
-            query = sql.SQL('DELETE FROM api_requests '
-                            'WHERE ended_at <= NOW() - interval \'%s day\';')
-            logger.info('Starting to clean up api requests data tables')
-            # Execute the query
-            self.cursor.execute(query.as_string(self.conn) % (num_days_api_requests))
-            # Log the message returned from db cursor
-            logger.info('%r' % self.cursor.statusmessage)
-            logger.info('Cleanup of api requests data tables complete')
+            self.cleanup_celery_task_metadata()
+            self.cleanup_celery_worker_results()
+            self.cleanup_package_analyses_data()
+            self.cleanup_package_worker_results_data()
+            self.cleanup_stack_analyses_request_data()
+            self.cleanup_api_requests_data()
         except Exception as e:
             logger.error('CleanupDatabaseError: %r' % e)
 

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -67,12 +67,12 @@ class ReportHelper:
     def cleanup_tables(self, table_name, column_name, num_days):
         """Cleanup tables on a periodic basis."""
         # Query to delete data
-        query = sql.SQL('DELETE FROM {0} WHERE {1} <= NOW() - interval \'%s day\';').format(
+        query = sql.SQL("DELETE FROM {0} WHERE {1} <= NOW() - interval %s day;").format(
             sql.Identifier(table_name),
             sql.Identifier(column_name)
         )
         logger.debug('Starting to clean up "%s" table', table_name)
-        self.cursor.execute(query.as_string(self.conn) % (num_days))
+        self.cursor.execute(query, (num_days,))
         self.conn.commit()
         # Log the message returned from db cursor
         logger.info('Cleanup of  "%s" table has completed with status %r', table_name,

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -66,15 +66,15 @@ class ReportHelper:
 
     def cleanup_tables(self, table_name, env_var, num_days):
         """Cleanup tables on a periodic basis."""
-        # Number of days to retain the celery task_meta data
-        num_days_metadata = os.environ.get(env_var, num_days)
+        # Number of days to retain the  data
+        num_days_data = os.environ.get(env_var, num_days)
         # Create query string
         delete_str = 'DELETE FROM ' + table_name + 'WHERE DATE_DONE <= NOW() - interval \'%s day\';'
         # query to delete data
         query = sql.SQL(delete_str)
         logger.debug('Starting to clean up ' + table_name + 'tables')
         # Execute the query
-        self.cursor.execute(query.as_string(self.conn) % (num_days_metadata))
+        self.cursor.execute(query.as_string(self.conn) % (num_days_data))
         # Save (commit) the changes
         self.conn.commit()
         # Log the message returned from db cursor

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -88,10 +88,10 @@ class ReportHelper:
             self.cleanup_tables('worker_results', 'ended_at', num_days)
 
             num_days = os.environ.get('KEEP_PACKAGE_ANALYSES_NUM_DAYS', '30')
-            #self.cleanup_tables('package_analyses', 'finished_at', num_days)
+            self.cleanup_tables('package_analyses', 'finished_at', num_days)
 
             num_days = os.environ.get('KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS', '30')
-            #self.cleanup_tables('package_worker_results','ended_at', num_days)
+            self.cleanup_tables('package_worker_results','ended_at', num_days)
 
             num_days = os.environ.get('KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS', '180')
             self.cleanup_tables('stack_analyses_request','submitTime', num_days)

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -64,113 +64,34 @@ class ReportHelper:
 
         self.emr_api = os.getenv('EMR_API', 'http://f8a-emr-deployment:6006')
 
-    def cleanup_celery_task_metadata(self):
-        """Cleanup celery task metadata tables on a periodic basis."""
+    def cleanup_tables(self, table_name, env_var, num_days):
+        """Cleanup tables on a periodic basis."""
         # Number of days to retain the celery task_meta data
-        num_days_metadata = os.environ.get('KEEP_DB_META_NUM_DAYS', '30')
-        # query to delete the celery task_meta data
-        query = sql.SQL('DELETE FROM celery_taskmeta '
-                        'WHERE DATE_DONE <= NOW() - interval \'%s day\';')
-        logger.info('Starting to clean up Celery Meta tables')
+        num_days_metadata = os.environ.get(env_var, num_days)
+        # Create query string
+        delete_str = 'DELETE FROM ' + table_name + 'WHERE DATE_DONE <= NOW() - interval \'%s day\';'
+        # query to delete data
+        query = sql.SQL(delete_str)
+        logger.debug('Starting to clean up ' + table_name + 'tables')
         # Execute the query
         self.cursor.execute(query.as_string(self.conn) % (num_days_metadata))
         # Save (commit) the changes
         self.conn.commit()
         # Log the message returned from db cursor
-        logger.info('%r' % self.cursor.statusmessage)
-        logger.info('Cleanup of Celery Meta tables complete')
-
-    def cleanup_celery_worker_results(self):
-        """Cleanup worker results data tables on a periodic basis."""
-        # Number of days to retain the celery woker_result data
-        num_days_workerdata = os.environ.get('KEEP_WORKER_RESULT_NUM_DAYS', '30')
-        # query to delete the worker_result data
-        query = sql.SQL('DELETE FROM worker_results '
-                        'WHERE ended_at <= NOW() - interval \'%s day\';')
-        logger.info('Starting to clean up Worker Result data tables')
-        # Execute the query
-        self.cursor.execute(query.as_string(self.conn) % (num_days_workerdata))
-        # Save (commit) the changes
-        self.conn.commit()
-        # Log the message returned from db cursor
-        logger.info('%r' % self.cursor.statusmessage)
-        logger.info('Cleanup of Worker Result data tables complete')
-
-    def cleanup_package_analyses_data(self):
-        """Cleanup package analyses data tables on a periodic basis."""
-        # Number of days to retain the package_analyses data
-        num_days_package_analyses = os.environ.get('KEEP_PACKAGE_ANALYSES_NUM_DAYS', '30')
-        # query to delete the package_analyses data
-        query = sql.SQL('DELETE FROM package_analyses '
-                        'WHERE ended_at <= NOW() - interval \'%s day\';')
-        logger.debug('Starting to clean up Package Analyses data tables')
-        # Execute the query
-        self.cursor.execute(query.as_string(self.conn) % (num_days_package_analyses))
-        # Save (commit) the changes
-        self.conn.commit()
-        # Log the message returned from db cursor
         logger.debug('%r' % self.cursor.statusmessage)
-        logger.info('Cleanup of Package Analyses data tables complete')
-
-    def cleanup_package_worker_results_data(self):
-        """Cleanup package worker results data tables on a periodic basis."""
-        # Number of days to retain the package_worker_result data
-        num_days_package_worker_result = os.environ.get
-        ('KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS', '30')
-        # query to delete the package_worker_result data
-        query = sql.SQL('DELETE FROM package_worker_results '
-                        'WHERE ended_at <= NOW() - interval \'%s day\';')
-        logger.info('Starting to clean up Package Worker Result data tables')
-        # Execute the query
-        self.cursor.execute(query.as_string(self.conn) % (num_days_package_worker_result))
-        # Save (commit) the changes
-        self.conn.commit()
-        # Log the message returned from db cursor
-        logger.info('%r' % self.cursor.statusmessage)
-        logger.info('Cleanup of Package Worker Result data tables complete')
-
-    def cleanup_stack_analyses_request_data(self):
-        """Cleanup stack analyses data tables on a periodic basis."""
-        # Number of days to retain the stack_analyses_request data
-        num_days_stack_analyses_request = os.environ.get
-        ('KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS', '180')
-        # query to delete the stack_analyses_request data
-        query = sql.SQL('DELETE FROM stack_analyses_request '
-                        'WHERE DATE_DONE <= NOW() - interval \'%s day\';')
-        logger.info('Starting to clean up Stack Analyses tables')
-        # Execute the query
-        self.cursor.execute(query.as_string(self.conn) % (num_days_stack_analyses_request))
-        # Save (commit) the changes
-        self.conn.commit()
-        # Log the message returned from db cursor
-        logger.info('%r' % self.cursor.statusmessage)
-        logger.info('Cleanup of Stack Analyses tables complete')
-
-    def cleanup_api_requests_data(self):
-        """Cleanup api request data tables on a periodic basis."""
-        # Number of days to retain the api_requests data
-        num_days_api_requests = os.environ.get('KEEP_API_REQUESTS_NUM_DAYS', '180')
-        # query to delete the api_requests data
-        query = sql.SQL('DELETE FROM api_requests '
-                        'WHERE ended_at <= NOW() - interval \'%s day\';')
-        logger.info('Starting to clean up api requests data tables')
-        # Execute the query
-        self.cursor.execute(query.as_string(self.conn) % (num_days_api_requests))
-        # Save (commit) the changes
-        self.conn.commit()
-        # Log the message returned from db cursor
-        logger.info('%r' % self.cursor.statusmessage)
-        logger.info('Cleanup of api requests data tables complete')
+        logger.info('Cleanup of ' + table_name + 'tables complete')
 
     def cleanup_db_tables(self):
         """Cleanup RDS data tables on a periodic basis."""
         try:
-            self.cleanup_celery_task_metadata()
-            self.cleanup_celery_worker_results()
-            self.cleanup_package_analyses_data()
-            self.cleanup_package_worker_results_data()
-            self.cleanup_stack_analyses_request_data()
-            self.cleanup_api_requests_data()
+            self.cleanup_tables('celery_taskmeta ', 'KEEP_DB_META_NUM_DAYS', '30')
+            self.cleanup_tables('worker_results ', 'KEEP_WORKER_RESULT_NUM_DAYS', '30')
+            self.cleanup_tables('package_analyses ', 'KEEP_PACKAGE_ANALYSES_NUM_DAYS', '30')
+            self.cleanup_tables
+            ('package_worker_results ', 'KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS', '30')
+            self.cleanup_tables
+            ('stack_analyses_request ', 'KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS', '180')
+            self.cleanup_tables('api_requests ', 'KEEP_API_REQUESTS_NUM_DAYS', '180')
         except Exception as e:
             logger.error('CleanupDatabaseError: %r' % e)
 

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -72,6 +72,7 @@ class ReportHelper:
             sql.Identifier(column_name)
         )
         logger.debug('Starting to clean up "%s" table', table_name)
+        # Executing query
         self.cursor.execute(query, (num_days,))
         self.conn.commit()
         # Log the message returned from db cursor
@@ -81,21 +82,27 @@ class ReportHelper:
     def cleanup_db_tables(self):
         """Cleanup RDS data tables on a periodic basis."""
         try:
+            # Number of days to retain the celery task_meta data
             num_days = os.environ.get('KEEP_DB_META_NUM_DAYS', '30')
             self.cleanup_tables('celery_taskmeta', 'date_done', num_days)
 
+            # Number of days to retain the worker results data
             num_days = os.environ.get('KEEP_WORKER_RESULT_NUM_DAYS', '30')
             self.cleanup_tables('worker_results', 'ended_at', num_days)
 
+            # Number of days to retain the package analyses data
             num_days = os.environ.get('KEEP_PACKAGE_ANALYSES_NUM_DAYS', '30')
             self.cleanup_tables('package_analyses', 'finished_at', num_days)
 
+            # Number of days to retain the package worker results data
             num_days = os.environ.get('KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS', '30')
             self.cleanup_tables('package_worker_results', 'ended_at', num_days)
 
+            # Number of days to retain the stack analyses request data
             num_days = os.environ.get('KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS', '180')
             self.cleanup_tables('stack_analyses_request', 'submitTime', num_days)
 
+            # Number of days to retain the api requests data
             num_days = os.environ.get('KEEP_API_REQUESTS_NUM_DAYS', '180')
             self.cleanup_tables('api_requests', 'submit_time', num_days)
         except Exception as e:

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -91,13 +91,13 @@ class ReportHelper:
             self.cleanup_tables('package_analyses', 'finished_at', num_days)
 
             num_days = os.environ.get('KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS', '30')
-            self.cleanup_tables('package_worker_results','ended_at', num_days)
+            self.cleanup_tables('package_worker_results', 'ended_at', num_days)
 
             num_days = os.environ.get('KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS', '180')
-            self.cleanup_tables('stack_analyses_request','submitTime', num_days)
+            self.cleanup_tables('stack_analyses_request', 'submitTime', num_days)
 
             num_days = os.environ.get('KEEP_API_REQUESTS_NUM_DAYS', '180')
-            self.cleanup_tables('api_requests','submit_time', num_days)
+            self.cleanup_tables('api_requests', 'submit_time', num_days)
         except Exception as e:
             logger.error('CleanupDatabaseError: %r' % e)
 

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -68,7 +68,7 @@ class ReportHelper:
         """Cleanup RDS data tables on a periodic basis."""
         try:
             # Number of days to retain the celery task_meta data
-            num_days_metadata = os.environ.get('KEEP_DB_META_NUM_DAYS', '7')
+            num_days_metadata = os.environ.get('KEEP_DB_META_NUM_DAYS', '30')
             # query to delete the celery task_meta data
             query = sql.SQL('DELETE FROM celery_taskmeta '
                             'WHERE DATE_DONE <= NOW() - interval \'%s day\';')
@@ -80,7 +80,7 @@ class ReportHelper:
             logger.info('Cleanup of Celery Meta tables complete')
 
             # Number of days to retain the celery woker_result data
-            num_days_workerdata = os.environ.get('KEEP_WORKER_RESULT_NUM_DAYS', '365')
+            num_days_workerdata = os.environ.get('KEEP_WORKER_RESULT_NUM_DAYS', '30')
             # query to delete the worker_result data
             query = sql.SQL('DELETE FROM worker_results '
                             'WHERE ended_at <= NOW() - interval \'%s day\';')

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -69,7 +69,7 @@ class ReportHelper:
         # query to delete data
         query = sql.SQL("""DELETE FROM {} WHERE DATE_DONE <= NOW() - interval '%s' day;""").format
         (sql.Identifier(table_name))
-        logger.debug('Starting to clean up ' + table_name + 'tables')
+        logger.debug('Starting to clean up "%s" table', table_name)
         self.cursor.execute(query, num_days)
         self.conn.commit()
         # Log the message returned from db cursor
@@ -80,22 +80,22 @@ class ReportHelper:
         """Cleanup RDS data tables on a periodic basis."""
         try:
             num_days = os.environ.get('KEEP_DB_META_NUM_DAYS', '30')
-            self.cleanup_tables('celery_taskmeta ', num_days)
+            self.cleanup_tables('celery_taskmeta', num_days)
 
             num_days = os.environ.get('KEEP_WORKER_RESULT_NUM_DAYS', '30')
-            self.cleanup_tables('worker_results ', num_days)
+            self.cleanup_tables('worker_results', num_days)
 
             num_days = os.environ.get('KEEP_PACKAGE_ANALYSES_NUM_DAYS', '30')
-            self.cleanup_tables('package_analyses ', num_days)
+            self.cleanup_tables('package_analyses', num_days)
 
             num_days = os.environ.get('KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS', '30')
-            self.cleanup_tables('package_worker_results ', num_days)
+            self.cleanup_tables('package_worker_results', num_days)
 
             num_days = os.environ.get('KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS', '180')
-            self.cleanup_tables('stack_analyses_request ', num_days)
+            self.cleanup_tables('stack_analyses_request', num_days)
 
             num_days = os.environ.get('KEEP_API_REQUESTS_NUM_DAYS', '180')
-            self.cleanup_tables('api_requests ', num_days)
+            self.cleanup_tables('api_requests', num_days)
         except Exception as e:
             logger.error('CleanupDatabaseError: %r' % e)
 

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -74,6 +74,8 @@ class ReportHelper:
         logger.info('Starting to clean up Celery Meta tables')
         # Execute the query
         self.cursor.execute(query.as_string(self.conn) % (num_days_metadata))
+        # Save (commit) the changes
+        self.conn.commit()
         # Log the message returned from db cursor
         logger.info('%r' % self.cursor.statusmessage)
         logger.info('Cleanup of Celery Meta tables complete')
@@ -88,6 +90,8 @@ class ReportHelper:
         logger.info('Starting to clean up Worker Result data tables')
         # Execute the query
         self.cursor.execute(query.as_string(self.conn) % (num_days_workerdata))
+        # Save (commit) the changes
+        self.conn.commit()
         # Log the message returned from db cursor
         logger.info('%r' % self.cursor.statusmessage)
         logger.info('Cleanup of Worker Result data tables complete')
@@ -96,14 +100,16 @@ class ReportHelper:
         """Cleanup package analyses data tables on a periodic basis."""
         # Number of days to retain the package_analyses data
         num_days_package_analyses = os.environ.get('KEEP_PACKAGE_ANALYSES_NUM_DAYS', '30')
-        # query to delete the worker_result data
+        # query to delete the package_analyses data
         query = sql.SQL('DELETE FROM package_analyses '
                         'WHERE ended_at <= NOW() - interval \'%s day\';')
-        logger.info('Starting to clean up Package Analyses data tables')
+        logger.debug('Starting to clean up Package Analyses data tables')
         # Execute the query
         self.cursor.execute(query.as_string(self.conn) % (num_days_package_analyses))
+        # Save (commit) the changes
+        self.conn.commit()
         # Log the message returned from db cursor
-        logger.info('%r' % self.cursor.statusmessage)
+        logger.debug('%r' % self.cursor.statusmessage)
         logger.info('Cleanup of Package Analyses data tables complete')
 
     def cleanup_package_worker_results_data(self):
@@ -111,12 +117,14 @@ class ReportHelper:
         # Number of days to retain the package_worker_result data
         num_days_package_worker_result = os.environ.get
         ('KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS', '30')
-        # query to delete the worker_result data
+        # query to delete the package_worker_result data
         query = sql.SQL('DELETE FROM package_worker_results '
                         'WHERE ended_at <= NOW() - interval \'%s day\';')
         logger.info('Starting to clean up Package Worker Result data tables')
         # Execute the query
         self.cursor.execute(query.as_string(self.conn) % (num_days_package_worker_result))
+        # Save (commit) the changes
+        self.conn.commit()
         # Log the message returned from db cursor
         logger.info('%r' % self.cursor.statusmessage)
         logger.info('Cleanup of Package Worker Result data tables complete')
@@ -132,6 +140,8 @@ class ReportHelper:
         logger.info('Starting to clean up Stack Analyses tables')
         # Execute the query
         self.cursor.execute(query.as_string(self.conn) % (num_days_stack_analyses_request))
+        # Save (commit) the changes
+        self.conn.commit()
         # Log the message returned from db cursor
         logger.info('%r' % self.cursor.statusmessage)
         logger.info('Cleanup of Stack Analyses tables complete')
@@ -146,6 +156,8 @@ class ReportHelper:
         logger.info('Starting to clean up api requests data tables')
         # Execute the query
         self.cursor.execute(query.as_string(self.conn) % (num_days_api_requests))
+        # Save (commit) the changes
+        self.conn.commit()
         # Log the message returned from db cursor
         logger.info('%r' % self.cursor.statusmessage)
         logger.info('Cleanup of api requests data tables complete')

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -90,6 +90,18 @@ class ReportHelper:
             # Log the message returned from db cursor
             logger.info('%r' % self.cursor.statusmessage)
             logger.info('Cleanup of Worker Result data tables complete')
+
+            # Number of days to retain the stack_analyses_request data
+            num_days_stack_analyses_request = os.environ.get('KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS', '180')
+            # query to delete the stack_analyses_request data
+            query = sql.SQL('DELETE FROM stack_analyses_request '
+                            'WHERE DATE_DONE <= NOW() - interval \'%s day\';')
+            logger.info('Starting to clean up Stack Analyses tables')
+            # Execute the query
+            self.cursor.execute(query.as_string(self.conn) % (num_days_stack_analyses_request))
+            # Log the message returned from db cursor
+            logger.info('%r' % self.cursor.statusmessage)
+            logger.info('Cleanup of Stack Analyses tables complete')
         except Exception as e:
             logger.error('CleanupDatabaseError: %r' % e)
 

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -67,7 +67,7 @@ class ReportHelper:
     def cleanup_tables(self, table_name, num_days):
         """Cleanup tables on a periodic basis."""
         # query to delete data
-        query = sql.SQL("""DELETE FROM {} WHERE DATE_DONE <= NOW() - interval '%s' day;""").format
+        query = sql.SQL("""DELETE FROM {} WHERE DATE_DONE <= NOW() - interval '%s day';""").format
         (sql.Identifier(table_name))
         logger.debug('Starting to clean up "%s" table', table_name)
         self.cursor.execute(query, num_days)

--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -92,7 +92,8 @@ class ReportHelper:
             logger.info('Cleanup of Worker Result data tables complete')
 
             # Number of days to retain the stack_analyses_request data
-            num_days_stack_analyses_request = os.environ.get('KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS', '180')
+            num_days_stack_analyses_request = os.environ.get
+            ('KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS', '180')
             # query to delete the stack_analyses_request data
             query = sql.SQL('DELETE FROM stack_analyses_request '
                             'WHERE DATE_DONE <= NOW() - interval \'%s day\';')
@@ -102,6 +103,18 @@ class ReportHelper:
             # Log the message returned from db cursor
             logger.info('%r' % self.cursor.statusmessage)
             logger.info('Cleanup of Stack Analyses tables complete')
+
+            # Number of days to retain the worker_results data
+            num_days_worker_results = os.environ.get('KEEP_WORKER_RESULTS_NUM_DAYS', '365')
+            # query to delete the stack_analyses_request data
+            query = sql.SQL('DELETE FROM worker_results '
+                            'WHERE DATE_DONE <= NOW() - interval \'%s day\';')
+            logger.info('Starting to clean up Worker results tables')
+            # Execute the query
+            self.cursor.execute(query.as_string(self.conn) % (num_days_worker_results))
+            # Log the message returned from db cursor
+            logger.info('%r' % self.cursor.statusmessage)
+            logger.info('Cleanup of Worker results tables complete')
         except Exception as e:
             logger.error('CleanupDatabaseError: %r' % e)
 

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -57,6 +57,18 @@ objects:
                   value: "25"
                 - name: PGBOUNCER_SERVICE_HOST
                   value: bayesian-pgbouncer
+                - name: KEEP_DB_META_NUM_DAYS
+                  value: 30
+                - name: KEEP_WORKER_RESULT_NUM_DAYS
+                  value: 30
+                - name: KEEP_PACKAGE_ANALYSES_NUM_DAYS
+                  value: 30
+                - name: KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS
+                  value: 30
+                - name: KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS
+                  value: 180
+                 - name: KEEP_API_REQUESTS_NUM_DAYS
+                  value: 180   
                 - name: SNYK_API_TOKEN_VALIDATION_URL
                   valueFrom:
                     configMapKeyRef:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -58,17 +58,17 @@ objects:
                 - name: PGBOUNCER_SERVICE_HOST
                   value: bayesian-pgbouncer
                 - name: KEEP_DB_META_NUM_DAYS
-                  value: 30
+                  value: "30"
                 - name: KEEP_WORKER_RESULT_NUM_DAYS
-                  value: 30
+                  value: "30"
                 - name: KEEP_PACKAGE_ANALYSES_NUM_DAYS
-                  value: 30
+                  value: "30"
                 - name: KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS
-                  value: 30
+                  value: "30"
                 - name: KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS
-                  value: 180
+                  value: "180"
                  - name: KEEP_API_REQUESTS_NUM_DAYS
-                  value: 180   
+                  value: "180"   
                 - name: SNYK_API_TOKEN_VALIDATION_URL
                   valueFrom:
                     configMapKeyRef:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -67,7 +67,7 @@ objects:
                   value: "30"
                 - name: KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS
                   value: "180"
-                 - name: KEEP_API_REQUESTS_NUM_DAYS
+                - name: KEEP_API_REQUESTS_NUM_DAYS
                   value: "180"   
                 - name: SNYK_API_TOKEN_VALIDATION_URL
                   valueFrom:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -35,10 +35,6 @@ objects:
                   value: "8182"
                 - name: GITHUB_CVE_REPO
                   value: ${GITHUB_CVE_REPO}
-                - name: KEEP_DB_META_NUM_DAYS
-                  value: ${KEEP_DB_META_NUM_DAYS}
-                - name: KEEP_WORKER_RESULT_NUM_DAYS
-                  value: ${KEEP_WORKER_RESULT_NUM_DAYS}
                 - name: GENERATE_MANIFESTS
                   value: ${GENERATE_MANIFESTS}
                 - name: SENTRY_API_ISSUES
@@ -58,17 +54,17 @@ objects:
                 - name: PGBOUNCER_SERVICE_HOST
                   value: bayesian-pgbouncer
                 - name: KEEP_DB_META_NUM_DAYS
-                  value: "30"
+                  value: ${KEEP_DB_META_NUM_DAYS}
                 - name: KEEP_WORKER_RESULT_NUM_DAYS
-                  value: "30"
+                  value: ${KEEP_WORKER_RESULT_NUM_DAYS}
                 - name: KEEP_PACKAGE_ANALYSES_NUM_DAYS
-                  value: "30"
+                  value: ${KEEP_PACKAGE_ANALYSES_NUM_DAYS}
                 - name: KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS
-                  value: "30"
+                  value: ${KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS}
                 - name: KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS
-                  value: "180"
+                  value: ${KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS}
                 - name: KEEP_API_REQUESTS_NUM_DAYS
-                  value: "180"   
+                  value: ${KEEP_API_REQUESTS_NUM_DAYS}   
                 - name: SNYK_API_TOKEN_VALIDATION_URL
                   valueFrom:
                     configMapKeyRef:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -54,17 +54,17 @@ objects:
                 - name: PGBOUNCER_SERVICE_HOST
                   value: bayesian-pgbouncer
                 - name: KEEP_DB_META_NUM_DAYS
-                  value: ${KEEP_DB_META_NUM_DAYS}
+                  value: "30"
                 - name: KEEP_WORKER_RESULT_NUM_DAYS
-                  value: ${KEEP_WORKER_RESULT_NUM_DAYS}
+                  value: "30"
                 - name: KEEP_PACKAGE_ANALYSES_NUM_DAYS
-                  value: ${KEEP_PACKAGE_ANALYSES_NUM_DAYS}
+                  value: "30"
                 - name: KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS
-                  value: ${KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS}
+                  value: "30"
                 - name: KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS
                   value: "180"
                 - name: KEEP_API_REQUESTS_NUM_DAYS
-                  value: ${KEEP_API_REQUESTS_NUM_DAYS}   
+                  value: "180"   
                 - name: SNYK_API_TOKEN_VALIDATION_URL
                   valueFrom:
                     configMapKeyRef:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -62,7 +62,7 @@ objects:
                 - name: KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS
                   value: ${KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS}
                 - name: KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS
-                  value: ${KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS}
+                  value: "180"
                 - name: KEEP_API_REQUESTS_NUM_DAYS
                   value: ${KEEP_API_REQUESTS_NUM_DAYS}   
                 - name: SNYK_API_TOKEN_VALIDATION_URL


### PR DESCRIPTION
The production DB is close to filling up in the next year or so.  We need to look at what we are storing, optimise for it and then look at purging or archiving older data.

#### Proposal for Cleanup
- [X] api_requests  6 months
- [X] celery_taskmeta  1 month
- [X] stack_analyses_request  6 months
- [X] worker_results  1 month
- [X] package_analyses  1 month
- [X] package_worker_results  1 month