### PR TITLE
fix: Purge data as table `package_worker_results` has reference to package_analyses table

### DIFF
--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -90,13 +90,13 @@ class ReportHelper:
             num_days = os.environ.get('KEEP_WORKER_RESULT_NUM_DAYS', '30')
             self.cleanup_tables('worker_results', 'ended_at', num_days)
 
-            # Number of days to retain the package analyses data
-            num_days = os.environ.get('KEEP_PACKAGE_ANALYSES_NUM_DAYS', '30')
-            self.cleanup_tables('package_analyses', 'finished_at', num_days)
-
             # Number of days to retain the package worker results data
             num_days = os.environ.get('KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS', '30')
             self.cleanup_tables('package_worker_results', 'ended_at', num_days)
+
+            # Number of days to retain the package analyses data
+            num_days = os.environ.get('KEEP_PACKAGE_ANALYSES_NUM_DAYS', '30')
+            self.cleanup_tables('package_analyses', 'finished_at', num_days)
 
             # Number of days to retain the stack analyses request data
             num_days = os.environ.get('KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS', '180')


### PR DESCRIPTION
This pr changes the order in which tables are purged i.e `package_worker_results` is purged before package_analyses table.