### PR TITLE
fix: Use column dep_snapshot to fetch SA manifests and remove reference to requestJson

### DIFF
--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -162,7 +162,7 @@ class ReportHelper:
 
         # Query to fetch Stack Analysis manifests data from start_date to end_date
         query = sql.SQL('SELECT {} FROM {} WHERE {} BETWEEN \'%s\' AND \'%s\'').format(
-            sql.Identifier('requestJson'), sql.Identifier('stack_analyses_request'),
+            sql.Identifier('dep_snapshot'), sql.Identifier('stack_analyses_request'),
             sql.Identifier('submitTime')
         )
         # Executing Query


### PR DESCRIPTION
Since we are removing the requestJson column from the stack analyses table all references to it have to be removed.