### PR TITLE
fix: Increase the number of days to retain data for `package_analyses` table.

### DIFF
--- a/f8a_report/helpers/report_helper.py
+++ b/f8a_report/helpers/report_helper.py
@@ -139,7 +139,7 @@ class ReportHelper:
         self.cleanup_tables('package_worker_results', 'ended_at', num_days)
 
         # Number of days to retain the package analyses data
-        num_days = os.environ.get('KEEP_PACKAGE_ANALYSES_NUM_DAYS', '31')
+        num_days = os.environ.get('KEEP_PACKAGE_ANALYSES_NUM_DAYS', '35')
         self.cleanup_tables('package_analyses', 'finished_at', num_days)
 
     def validate_and_process_date(self, some_date):

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -58,7 +58,7 @@ objects:
                 - name: KEEP_WORKER_RESULT_NUM_DAYS
                   value: "30"
                 - name: KEEP_PACKAGE_ANALYSES_NUM_DAYS
-                  value: "31"
+                  value: "35"
                 - name: KEEP_PACKAGE_WORKER_RESULT_NUM_DAYS
                   value: "30"
                 - name: KEEP_STACK_ANALYSES_REQUESTS_NUM_DAYS


### PR DESCRIPTION
Currently the clean up of package_analyses table fails due to foreign key reference from package_worker_results table.