### PR TITLE
chore: Remove configs for PVC creation

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -226,16 +226,6 @@ objects:
               - name: bayesian-user-pvc
                 persistentVolumeClaim:
                   claimName: bayesian-user-pvc
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: bayesian-user-pvc
-  spec:
-    accessModes:
-      - ReadWriteMany
-    resources:
-      requests:
-        storage: 1Gi
 parameters:
 - description: Docker registry
   displayName: Docker registry


### PR DESCRIPTION
PVC creation can not be done in this repo as it is used in multiple cron jobs and same template is used by all cron jobs which creates issue while deploying using CI/CD framework. 