### PR TITLE
Revert "RDS user caching into PVC"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-ENV APP_DIR='/f8a_report' DB_CACHE_DIR="/db-cache"
+ENV APP_DIR='/f8a_report'
 ENV PYTHONPATH=.
 WORKDIR ${APP_DIR}
 

--- a/f8a_report/helpers/db_gateway.py
+++ b/f8a_report/helpers/db_gateway.py
@@ -148,14 +148,3 @@ class TokenValidationQueries(Postgres):
             self.conn.commit()
         finally:
             self.conn.close()
-
-    def get_all_user(self) -> dict:
-        """Get all users from RDS table."""
-        try:
-            logger.info("Getting all users for caching")
-            get_all_user_sql = sql.SQL("select * from user_details")
-            self.cursor.execute(get_all_user_sql.as_string(self.conn))
-            result = self.cursor.fetchall()
-            return result
-        finally:
-            self.conn.close()

--- a/f8a_report/snyk_token_validation_main.py
+++ b/f8a_report/snyk_token_validation_main.py
@@ -3,11 +3,8 @@
 from f8a_report.helpers.db_gateway import TokenValidationQueries
 from f8a_utils.user_token_utils import decrypt_api_token, is_snyk_token_valid
 import logging
-import json
-import os
 
 logger = logging.getLogger(__file__)
-DB_CACHE_FILE_PATH = os.environ.get("DB_CACHE_DIR")
 
 
 def main():
@@ -15,7 +12,6 @@ def main():
     user_to_tokens = TokenValidationQueries().get_registered_user_tokens()
     unregistered_users = call_snyk_api(user_to_tokens)
     TokenValidationQueries().update_users_to_unregistered(unregistered_users)
-    cache_all_users(TokenValidationQueries().get_all_user())
 
 
 def call_snyk_api(user_to_tokens: dict) -> list:
@@ -28,21 +24,6 @@ def call_snyk_api(user_to_tokens: dict) -> list:
             unregistered_users.append(user_id)
 
     return unregistered_users
-
-
-def cache_all_users(users: dict):
-    """Cache users in PVC."""
-    for user in users:
-        user_cache = {
-            "user_id": user[0], "snyk_api_token": user[1],
-            "last_validated_date": user[2], "status": user[3],
-            "registered_date": user[4], "created_date": user[5],
-            "updated_date": user[6], "user_source": user[7]
-        }
-
-        # Create file for each user into PVC having details about user
-        with open(DB_CACHE_FILE_PATH + "/" + user[0] + ".json", 'w', encoding='utf-8') as file:
-            json.dump(user_cache, file, ensure_ascii=False, indent=4, default=str)
 
 
 if __name__ == '__main__':

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -219,23 +219,6 @@ objects:
                 limits:
                   memory: ${MEMORY_LIMIT}
                   cpu: ${CPU_LIMIT}
-              volumeMounts:
-                - mountPath: "/db-cache"
-                  name: bayesian-user-pvc
-            volumes:
-              - name: bayesian-user-pvc
-                persistentVolumeClaim:
-                  claimName: bayesian-user-pvc
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: bayesian-user-pvc
-  spec:
-    accessModes:
-      - ReadWriteMany
-    resources:
-      requests:
-        storage: 1Gi
 parameters:
 - description: Docker registry
   displayName: Docker registry

--- a/tests/test_snyk_token_validation.py
+++ b/tests/test_snyk_token_validation.py
@@ -32,20 +32,15 @@ class TestSnykTokenValidation(unittest.TestCase):
 
     @patch.object(TokenValidationQueries, 'get_registered_user_tokens')
     @patch.object(TokenValidationQueries, 'update_users_to_unregistered')
-    @patch.object(TokenValidationQueries, 'get_all_user')
     @patch('f8a_report.snyk_token_validation_main.decrypt_api_token')
     @patch('f8a_report.snyk_token_validation_main.is_snyk_token_valid')
     def test_main(self, is_snyk_token_valid, decrypt_api_token,
-                  update_users_to_unregistered, get_registered_user_tokens,
-                  get_all_user):
+                  update_users_to_unregistered, get_registered_user_tokens):
         """Test cases for statement flow in main."""
         decrypt_api_token.return_value = b'gAAAAABfNTgGNBoO7RkDM'
         is_snyk_token_valid.return_value = False
-
         token_validation.main()
 
         get_registered_user_tokens.assert_called_once()
 
         update_users_to_unregistered.assert_called_once()
-
-        get_all_user.assert_called_once()


### PR DESCRIPTION
Reverts fabric8-analytics/f8a-stacks-report#211, because we are not creating PVC now in reports instead we are will be calling an API to create cache.